### PR TITLE
Hide signup section when already logged in and centered it (#174)

### DIFF
--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -1,19 +1,29 @@
-import React from 'react'
-import SelectionIcons from './components/SelectionIcons'
-import IntroContent from './components/IntroContent'
-import Header from './components/Header'
-import { Link } from 'react-router-dom'
+import React, { useEffect, useState } from 'react';
+import SelectionIcons from './components/SelectionIcons';
+import IntroContent from './components/IntroContent';
+import Header from './components/Header';
 
 function Home() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('authToken');
+    setIsAuthenticated(!!token);
+  }, []);
+
   return (
-  <>
-  <Header />
-    <div className='App'>
-      <SelectionIcons />
-      <IntroContent />
-    </div>
-  </>
+    <>
+      <Header />
+      <div className="App flex flex-col items-center justify-center min-h-screen bg-gray-50 text-center">
+        <div className="my-12">
+          <SelectionIcons />
+        </div>
+
+        {/* Show IntroContent if NOT logged in */}
+        {!isAuthenticated && <IntroContent />}
+      </div>
+    </>
   );
 }
 
-export default Home
+export default Home;


### PR DESCRIPTION
Hides Signup section when user is already logged in. Centers service icons on the Home page for better layout.

<img width="938" height="877" alt="image" src="https://github.com/user-attachments/assets/909cb5fe-2025-4870-b15a-f7abfc6618e4" />


closes #174 