### PR TITLE
“Cancel Booking” Button in the Chat Room

### DIFF
--- a/backend/routes/bookingRoutes.js
+++ b/backend/routes/bookingRoutes.js
@@ -7,6 +7,7 @@ import {
   updateBookingPrice,
   agreeToPrice,
   downloadAgreement,
+  cancelBooking
 } from "../controllers/bookingController.js";
 import { protect } from "../middleware/authMiddleware.js";
 
@@ -69,6 +70,7 @@ router.post("/", bookTask);
 router.put("/:id/price", updateBookingPrice);
 router.put("/:id/agree", agreeToPrice);
 router.get("/:id/agreement", downloadAgreement);
+router.put("/:id/cancel", protect, cancelBooking);
 // ✅ NEW ROUTE to mark booking as Paid and record payment details
 router.put("/:id/paid", async (req, res) => {
   try {

--- a/frontend/src/pages/components/ChatRoom.jsx
+++ b/frontend/src/pages/components/ChatRoom.jsx
@@ -284,9 +284,20 @@ const ChatRoom = () => {
         }
       };
 
-
-
-
+      const handleCancelBooking = async () => {
+        try {
+          const confirmCancel = window.confirm(
+            "Are you sure you want to cancel this booking?"
+          );
+          if (!confirmCancel) return;
+          const res = await api.put(`/bookings/${bookingId}/cancel`, {}, axiosConfig);
+          alert("Booking cancelled successfully.");
+          navigate("/");
+        } catch (err) {
+          console.error("Error cancelling booking:", err);
+          alert("Failed to cancel booking.");
+        }
+      };
 
   // ✅ Loading state
   if (loading) {
@@ -464,16 +475,21 @@ const ChatRoom = () => {
             <p>
               <strong>Status:</strong>{" "}
               <span
-                className={`px-2 py-0.5 rounded text-white ${
+                className={`px-2 py-0.5 rounded text-white font-medium ${
                   bookingDetails.status === "Negotiating"
                     ? "bg-yellow-500"
                     : bookingDetails.status === "Confirmed"
                     ? "bg-green-600"
+                    : bookingDetails.status === "Cancelled"
+                    ? "bg-red-600"
+                    : bookingDetails.status === "Completed"
+                    ? "bg-blue-600"
                     : "bg-gray-500"
                 }`}
               >
                 {bookingDetails.status}
               </span>
+
             </p>
 
             {/* 💬 Negotiation Section (both can propose until both agree) */}
@@ -597,6 +613,12 @@ const ChatRoom = () => {
                   }`}
                 >
                   ✅ Agree to Price
+                </button>
+                <button
+                  onClick={handleCancelBooking}
+                  className="w-full bg-red-600 text-white py-2 rounded hover:bg-red-700 transition"
+                >
+                  ❌ Cancel Booking
                 </button>
               </div>
             )}

--- a/frontend/src/pages/profile/components/user.jsx
+++ b/frontend/src/pages/profile/components/user.jsx
@@ -405,17 +405,25 @@ const User = () => {
                               : "N/A"}
                           </td>
                           <td className="px-4 py-2">
-                            <span
-                              className={`px-3 py-1 rounded-full text-xs font-medium ${
-                                b.status === "Paid"
-                                  ? "bg-green-100 text-green-700"
-                                  : b.status === "Pending"
-                                  ? "bg-yellow-100 text-yellow-700"
-                                  : "bg-blue-100 text-blue-700"
-                              }`}
-                            >
-                              {b.status}
-                            </span>
+                          <span
+                            className={`px-3 py-1 rounded-full text-xs font-medium ${
+                              b.status === "Paid"
+                                ? "bg-emerald-100 text-emerald-700"
+                                : b.status === "Confirmed"
+                                ? "bg-green-100 text-green-700"
+                                : b.status === "Negotiating"
+                                ? "bg-orange-100 text-orange-700"
+                                : b.status === "Pending"
+                                ? "bg-yellow-100 text-yellow-700"
+                                : b.status === "Completed"
+                                ? "bg-blue-100 text-blue-700"
+                                : b.status === "Cancelled"
+                                ? "bg-red-100 text-red-700"
+                                : "bg-gray-100 text-gray-700"
+                            }`}
+                          >
+                            {b.status}
+                          </span>
                           </td>
                         </tr>
                       ))}


### PR DESCRIPTION
# ✅ Pull Request Template

## 🧠 Description  
Added a “Cancel Booking” button in the Chat Room to allow users to cancel active or pending bookings directly within the chat interface.

This feature enhances user convenience by removing the need to navigate to the booking dashboard for cancellations. It also ensures immediate status updates across both client and provider views.
---
## 🔁 Related Issues  
Link the related issue(s):  

> Closes #167 

---

## 🧩 Type of Change  
- [ ] 🐛 Bug Fix  
- [x] ✨ New Feature  
- [ ] 🧹 Code Refactor / Optimization  
- [ ] 🧾 Documentation Update  
- [ ] 🧪 Test Update  
- [ ] ♻️ Maintenance / Dependency Update  

---

## 🧪 How Has This Been Tested?  
1. Open the Chat Room for an active booking.
2. Click the “Cancel Booking” button.
3. Confirm that booking status updates to “Cancelled” in both Chat Room and Booking History.
4. Verify appropriate color coding and status badge updates.
---

## 📸 Screenshots / Logs (if applicable)  
<img width="1860" height="900" alt="image" src="https://github.com/user-attachments/assets/e827e623-60ab-48de-8227-1fae76b552f7" />
<img width="668" height="379" alt="image" src="https://github.com/user-attachments/assets/4ac74f16-a780-402f-b454-25f42182ad92" />
<img width="755" height="358" alt="image" src="https://github.com/user-attachments/assets/66d11831-db09-4169-8ea7-e0803a88047a" />
<img width="1850" height="625" alt="image" src="https://github.com/user-attachments/assets/89030d22-7b54-40fa-94e3-6a61a947ca2d" />
